### PR TITLE
Update to add rabbit_exchange_type:policy_changed/3

### DIFF
--- a/src/udp_exchange.erl
+++ b/src/udp_exchange.erl
@@ -14,7 +14,7 @@
                     {enables,     kernel_ready}]}).
 
 -export([description/0, serialise_events/0, route/2]).
--export([validate/1, create/2, delete/3, add_binding/3,
+-export([validate/1, create/2, delete/3, policy_changed/3, add_binding/3,
 	 remove_bindings/3, assert_args_equivalence/2]).
 
 -export([truncate_bin/2]). %% utility
@@ -48,6 +48,8 @@ delete(transaction, X, _Bs) ->
     ok;
 delete(none, _X, _Bs) ->
     ok.
+
+policy_changed(_Tx, _X1, _X2) -> ok.
 
 add_binding(Tx, X, B) -> rabbit_exchange_type_topic:add_binding(Tx, X, B).
 remove_bindings(Tx, X, Bs) -> rabbit_exchange_type_topic:remove_bindings(Tx, X, Bs).


### PR DESCRIPTION
Hi. 2.9.0 will add another function to the exchange type API. In most cases this can be a no-op, so this is pretty trivial. When compiling against 2.8.x it's just an exported-but-unused function, so this can be applied immediately.
