### PR TITLE
Support plugin unloading.

### DIFF
--- a/src/udp_exchange.erl
+++ b/src/udp_exchange.erl
@@ -14,6 +14,8 @@
                    [{description, "exchange type x-udp"},
 		    {mfa,         {rabbit_registry, register,
 				   [exchange, ?EXCHANGE_TYPE_BIN, ?MODULE]}},
+		    {cleanup,     {rabbit_registry, unregister,
+				   [exchange, ?EXCHANGE_TYPE_BIN]}},
                     {requires,    rabbit_registry},
                     {enables,     recovery}]}).
 


### PR DESCRIPTION
RabbitMQ 3.4.0 will allow plugins to be enabled and disabled without restarting the broker. This change makes sure the registry forgets the plugin type before we unload it.
